### PR TITLE
fix: address code review issues (security, correctness, quality)

### DIFF
--- a/app/controllers/admin/episodes_controller.rb
+++ b/app/controllers/admin/episodes_controller.rb
@@ -19,7 +19,7 @@ module Admin
     end
 
     def create
-      @episode = Episode.new create_params
+      @episode = Episode.new episode_params
       @episode.slug = build_slug(@episode)
       if @episode.save
         redirect_to admin_episodes_path, notice: "Episode was successfully created."
@@ -34,8 +34,10 @@ module Admin
 
     def update
       @episode = Episode.find_by!(slug: params[:id])
+      @episode.assign_attributes(episode_params)
+      @episode.slug = build_slug(@episode)
 
-      if @episode.update(update_params) && @episode.update(slug: build_slug(@episode))
+      if @episode.save
         redirect_to admin_episodes_path, notice: "Episode was successfully updated."
       else
         render :edit
@@ -50,11 +52,7 @@ module Admin
       "#{episode.number.to_s.rjust(3, '0')} #{episode.title}".parameterize(locale: :de)
     end
 
-    def create_params
-      params.require(:episode).permit(*Episode::ATTRIBUTES)
-    end
-
-    def update_params
+    def episode_params
       params.require(:episode).permit(*Episode::ATTRIBUTES)
     end
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -8,6 +8,7 @@ module Users
       user = User.find_by(email: params[:email])
 
       if user&.authenticate(params[:password])
+        reset_session
         session[:user_id] = user.id
         redirect_to admin_statistics_path, notice: "Signed in successfully"
       else

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -13,9 +13,9 @@ class WelcomeController < ApplicationController
   def privacy
   end
 
-  def epsiode
-    epsiode_id = params[:id].to_i.positive? ? params[:id].to_i : nil
-    episode_record = Episode.find_by(number: epsiode_id) if epsiode_id
+  def episode
+    episode_id = params[:id].to_i.positive? ? params[:id].to_i : nil
+    episode_record = Episode.find_by(number: episode_id) if episode_id
 
     if episode_record
       redirect_to episode_path slug: episode_record.slug

--- a/app/jobs/geo_data_job.rb
+++ b/app/jobs/geo_data_job.rb
@@ -1,7 +1,8 @@
 class GeoDataJob < ApplicationJob
   queue_as :default
 
-  retry_on StandardError, wait: :polynomially_longer, attempts: 5
+  retry_on MaxMind::GeoIP2::HTTPError, wait: :polynomially_longer, attempts: 5
+  discard_on ActiveRecord::RecordNotFound
 
   def perform(event_id, remote_ip)
     event = Event.find event_id

--- a/app/presenters/podcast_feed_presenter.rb
+++ b/app/presenters/podcast_feed_presenter.rb
@@ -5,8 +5,8 @@ class PodcastFeedPresenter
 
   delegate_missing_to :current_setting
 
-  def initialize(episondes)
-    @episodes = EpisodeFeedPresenter.wrap episondes
+  def initialize(episodes)
+    @episodes = EpisodeFeedPresenter.wrap episodes
   end
 
   def copyright

--- a/app/presenters/statistic_presenter.rb
+++ b/app/presenters/statistic_presenter.rb
@@ -1,5 +1,5 @@
 class StatisticPresenter < ApplicationPresenter
-  FIELDS = %i[a12h a1d a7d a3d a7d a14d a30d a60d a3m a6m a12m a18m a24m].freeze
+  FIELDS = %i[a12h a1d a3d a7d a14d a30d a60d a3m a6m a12m a18m a24m].freeze
 
   FIELDS.each do |field|
     define_method(field) do

--- a/app/services/convert_chapters.rb
+++ b/app/services/convert_chapters.rb
@@ -1,4 +1,6 @@
 class ConvertChapters < BaseService
+  Chapter = Struct.new(:start, :title)
+
   attr_accessor :chapters
 
   def call
@@ -7,10 +9,10 @@ class ConvertChapters < BaseService
     chapters.split("\n").map do |chapter_mark|
       next if chapter_mark.blank?
 
-      result = chapter_mark.squish.match(/(?<timestamp>\d{2}(?<sperator>:\d{2})+)\.\d{3}\s+(?<text>.*)/)
+      result = chapter_mark.squish.match(/(?<timestamp>\d{2}(?<separator>:\d{2})+)\.\d{3}\s+(?<text>.*)/)
       next if result.blank?
 
-      OpenStruct.new(start: result[:timestamp].strip, title: result[:text].strip)
+      Chapter.new(result[:timestamp].strip, result[:text].strip)
     end.compact
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,5 +32,5 @@ Rails.application.routes.draw do
 
   get "/sitemap.xml.gz", to: redirect("https://wartenberger-podcast.s3.amazonaws.com/sitemap.xml.gz")
   # episode shortcut /006 or /2
-  get ":id", to: "welcome#epsiode", constraints: { id: /\d+/ }
+  get ":id", to: "welcome#episode", constraints: { id: /\d+/ }
 end

--- a/db/migrate/20260323000000_set_admin_default_on_users.rb
+++ b/db/migrate/20260323000000_set_admin_default_on_users.rb
@@ -1,0 +1,12 @@
+class SetAdminDefaultOnUsers < ActiveRecord::Migration[8.1]
+  def up
+    User.where(admin: nil).update_all(admin: false)
+    change_column_default :users, :admin, false
+    change_column_null :users, :admin, false
+  end
+
+  def down
+    change_column_null :users, :admin, true
+    change_column_default :users, :admin, nil
+  end
+end

--- a/spec/requests/episodes_spec.rb
+++ b/spec/requests/episodes_spec.rb
@@ -187,12 +187,9 @@ RSpec.describe "episodes", type: :request do
           </channel>
         </rss>)
 
-      # Debugging
-      File.write("response.xml", response.body.squish)
-      File.write("expected_xml.xml", expected_xml.squish)
       expect(response.body).to match_xml(expected_xml)
 
-      # remove epsiode from rss feed
+      # remove episode from rss feed
       episode2.update! rss_feed: false
       get "/episodes.rss"
 
@@ -248,8 +245,6 @@ RSpec.describe "episodes", type: :request do
           </channel>
         </rss>)
 
-      File.write("response.xml", response.body.squish)
-      File.write("expected_xml.xml", expected_xml.squish)
       expect(response.body).to match_xml(expected_xml)
     end
 
@@ -359,7 +354,6 @@ RSpec.describe "episodes", type: :request do
 
         expect do
           get episode.mp3_url, params: {}, env: { "REMOTE_ADDR": "192.168.1.2" }
-          sleep 1
           get episode.mp3_url, params: {}, env: { "REMOTE_ADDR": "192.168.1.2" }
           get episode2.mp3_url, params: {}, env: { "REMOTE_ADDR": "192.168.1.2" }
           get episode.mp3_url, params: {}, env: { "REMOTE_ADDR": "192.168.1.2" }

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "Sessions", type: :request do
+  let!(:user) { create(:user) }
+
+  describe "POST /login" do
+    context "with valid credentials" do
+      it "signs in and redirects to admin statistics" do
+        post "/login", params: { email: user.email, password: "Test123!" }
+
+        expect(response).to redirect_to(admin_statistics_path)
+      end
+
+      it "resets the session to prevent fixation" do
+        # Establish a session before login
+        get "/login"
+        old_session_id = session.id
+
+        post "/login", params: { email: user.email, password: "Test123!" }
+
+        expect(session.id).not_to eq(old_session_id)
+      end
+
+      it "sets user_id in session" do
+        post "/login", params: { email: user.email, password: "Test123!" }
+
+        expect(session[:user_id]).to eq(user.id)
+      end
+    end
+
+    context "with invalid credentials" do
+      it "re-renders the login form with 422" do
+        post "/login", params: { email: user.email, password: "wrong" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "does not set user_id in session" do
+        post "/login", params: { email: user.email, password: "wrong" }
+
+        expect(session[:user_id]).to be_nil
+      end
+    end
+  end
+
+  describe "DELETE /logout" do
+    before do
+      post "/login", params: { email: user.email, password: "Test123!" }
+    end
+
+    it "signs out and redirects to root" do
+      delete "/logout"
+
+      expect(response).to redirect_to(root_path)
+      expect(session[:user_id]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes issues identified in a full application code review.

**Security**
- Add reset_session before setting session user_id on login to prevent session fixation
- Add request specs covering the login/logout flow and session reset behavior

**Bug fixes**
- Admin::EpisodesController#update: replace two sequential update() calls with assign_attributes + save so episode params and slug are always persisted atomically
- StatisticPresenter::FIELDS: remove duplicate a7d entry
- GeoDataJob: replace broad retry_on StandardError with retry_on MaxMind::GeoIP2::HTTPError; add discard_on ActiveRecord::RecordNotFound

**Code quality**
- Replace OpenStruct with Struct in ConvertChapters (OpenStruct invalidates Ruby method dispatch cache globally)
- Fix typo :sperator -> :separator in ConvertChapters regex named capture group
- Fix typo episondes -> episodes in PodcastFeedPresenter#initialize
- Rename welcome#epsiode -> welcome#episode in controller and route
- Consolidate create_params / update_params into episode_params in Admin::EpisodesController

**Migration**
- users.admin boolean column had no NOT NULL or default — adds null: false, default: false after backfilling nil values

**Test cleanup**
- Remove leftover File.write debugging calls from the RSS feed spec
- Remove sleep 1 from the cache deduplication test

## Test plan

- [ ] bundle exec rails db:migrate
- [ ] bundle exec rspec spec/requests/sessions_spec.rb
- [ ] bundle exec rspec spec/requests/episodes_spec.rb
- [ ] bundle exec rspec spec/system/admin/episodes_spec.rb
- [ ] bundle exec rspec